### PR TITLE
feat: Skill Potential

### DIFF
--- a/character-sheet.css
+++ b/character-sheet.css
@@ -730,11 +730,16 @@ input[type="number"].sheet-full
     width: 100%;
 }
 
-
+/* IMAGES */
 
 .sheet-logo {
     max-height: 150px;
     min-width:  100px;
+    
+}
+
+.skill-potential-image {
+    max-width: 100px;
     
 }
 
@@ -931,4 +936,46 @@ input[type="number"].sheet-full
     opacity: 0;
     height: 0px;
     width: 0px;
+}
+
+.charsheet .grid-template {
+    display: grid;
+    grid-template-columns: auto auto;
+    background-color: #2196F3;
+    padding: 10px;
+
+}
+
+.charsheet .grid-item-template {
+    background-color: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(0, 0, 0, 0.8);
+    padding: 20px;
+    font-size: 30px;
+    text-align: center;
+  }
+
+  .charsheet .skill-potential-grid {
+    display: grid;
+    grid-template-columns: auto auto auto auto auto auto auto;
+    padding: 10px;
+
+}
+
+.charsheet .skill-potential-label {
+    background-color: rgba(255, 255, 255, 0.74);
+    font-size: 30px;
+    text-align: center;
+    font-weight: bold;
+    align-content: center;
+    font-family: fantasy;
+
+
+}
+
+.charsheet .skill-potential-value {
+    background-color: rgb(255, 255, 255);
+    font-size: 30px;
+    text-align: center;
+    font-weight: bold;
+
 }

--- a/character-sheet.html
+++ b/character-sheet.html
@@ -1003,14 +1003,239 @@
                             </tr>
                         </table>
                     </td>
-
-                    <!-- Profession Inner Table -->
                     <tr>
                         <td>
                             &nbsp;
                         </td>
                     </tr>
                 </table>
+<!-- SKILL POTENTIAL SECTION below -->
+                <h3>Skill Potential</h3>
+                <div class="skill-potential-grid">
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/902997898566979614/physical_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058361090703440/gun_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058377918263396/fire_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058397543403560/ice_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058425473290320/electric_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058447396925450/wind_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058469777707008/psychic_icon.png"/>
+                </div>
+                <div class="skill-potential-grid">
+                    <span class="skill-potential-label">Physical</span>
+                    <span class="skill-potential-label">Gun</span>
+                    <span class="skill-potential-label">Fire</span>
+                    <span class="skill-potential-label">Ice</span>
+                    <span class="skill-potential-label">Electric</span>
+                    <span class="skill-potential-label">Wind</span>
+                    <span class="skill-potential-label">Psychic</span>
+                </div>
+                    <div class="skill-potential-grid">
+                    <select class="skill-potential-value" name="attr_skill-potential-physical">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-gun">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-fire">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-ice">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-electric">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-wind">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-psychic">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                </div>
+
+                <div class="skill-potential-grid">
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058496549965824/nuke_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058550262235176/bless_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/903058567093977158/curse_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/931218887943548938/almighty_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/931218906436214834/ailment_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/931218861250973726/healing_icon.png"/>
+                    <img class="skill-potential-image" src="https://cdn.discordapp.com/attachments/900199385370071080/931218764014444574/support_icon.png"/>
+                </div>
+                <div class="skill-potential-grid">
+                    <span class="skill-potential-label">Nuke</span>
+                    <span class="skill-potential-label">Bless</span>
+                    <span class="skill-potential-label">Curse</span>
+                    <span class="skill-potential-label">Almighty</span>
+                    <span class="skill-potential-label">Ailment</span>
+                    <span class="skill-potential-label">Healing</span>
+                    <span class="skill-potential-label">Support</span>
+                </div>
+                <div class="skill-potential-grid">
+                    <select class="skill-potential-value" name="attr_skill-potential-nuke">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-bless">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-curse">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-almighty">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-ailment">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-healing">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                    <select class="skill-potential-value" name="attr_skill-potential-support">
+                        <option value="">0</option>
+                        <option value="+1">+1</option>
+                        <option value="+2">+2</option>
+                        <option value="+3">+3</option>
+                        <option value="+4">+4</option>
+                        <option value="+5">+5</option>
+                        <option value="-1">-1</option>
+                        <option value="-2">-2</option>
+                        <option value="-3">-3</option>
+                        <option value="-4">-4</option>
+                        <option value="-5">-5</option>
+                    </select>
+                </div>
+                    
+
             </div>
         </div>
 


### PR DESCRIPTION
Added a new section underneath the Stats and Traits page to account for "Skill Potential", which ranged from -5 to +5, defaulting at 0. It also experiments with grid-based layouts to begin replacing the use of tables.

Future updates will include an ability to automatically add these factors to the Skill when sent to chat.